### PR TITLE
Add NFT minting support and related error handling for badges

### DIFF
--- a/internal/errors/errorStr.go
+++ b/internal/errors/errorStr.go
@@ -41,9 +41,14 @@ const (
 	ErrCategoryAlreadyAdded   = "CATEGORY_ALREADY_ADDED_INTO_CAMPAIGN"
 	ErrUserBadgeAlreadyExists = "USER_BADGE_ALREADY_EXISTS"
 	ErrNotValidWalletAddress  = "NOT_VALID_WALLET_ADDRESS"
+	ErrImageRequried          = "IMAGE_REQUIRED"
 
 	// Donate
 	ErrInvalidTransactionInfo = "INVALID_TRANSACTION_INFO"
+
+	// Badge
+	ErrBadgeIsNotNFT    = "BADGE_IS_NOT_NFT"
+	ErrNFTAlreadyMinted = "NFT_IS_ALREADY_MINTED"
 )
 
 // 500
@@ -69,6 +74,7 @@ const (
 	ErrUpdatingUsers      = "ERROR_UPDATING_USERS"
 	ErrUpdatingCategories = "ERROR_UPDATING_CATEGORIES"
 	ErrUpdatingBadge      = "ERROR_UPDATING_BADGE"
+	ErrChangingMinted     = "ERROR_WHILE_CHANGING_IS_MINTED"
 
 	ErrDeletingCampaigns        = "ERROR_DELETING_CAMPAIGNS"
 	ErrDeletingDonations        = "ERROR_DELETING_DONATIONS"

--- a/internal/http/dtos/badges.go
+++ b/internal/http/dtos/badges.go
@@ -54,6 +54,7 @@ type BadgeView struct {
 	SellerFee   int32  `json:"sellerFee"`
 	Threshold   int32  `json:"threshold"`
 	IsNft       bool   `json:"isNft"`
+	IsMinted    bool   `json:"isMinted"`
 }
 
 type BadgeViews struct {
@@ -85,6 +86,35 @@ func (m *BadgeDTOManager) ToBadgeViews(badges []repo.TBadge, count int64) *Badge
 	var badgeViews []BadgeView
 	for _, badge := range badges {
 		badgeViews = append(badgeViews, *m.ToBadgeView(&badge))
+	}
+	return &BadgeViews{Badges: badgeViews, TotalCount: int(count)}
+}
+
+// ToBadgeView transforms domain badge to BadgeView
+func (BadgeDTOManager) ToUserBadgeView(badge *repo.GetUserBadgesRow) *BadgeView {
+	if badge == nil {
+		return nil
+	}
+
+	return &BadgeView{
+		ID:          badge.ID.String(),
+		Symbol:      badge.Symbol.String,
+		Name:        badge.Name,
+		Description: badge.Description.String,
+		SellerFee:   badge.SellerFee.Int32,
+		Uri:         badge.Uri.String,
+		IsNft:       badge.IsNft,
+		IconPath:    badge.IconPath.String,
+		Threshold:   badge.DonationThreshold,
+		IsMinted:    badge.IsMinted,
+	}
+}
+
+// ToBadgeViews transforms list of badges to BadgeViews
+func (m *BadgeDTOManager) ToUserBadgeViews(badges []repo.GetUserBadgesRow, count int64) *BadgeViews {
+	var badgeViews []BadgeView
+	for _, badge := range badges {
+		badgeViews = append(badgeViews, *m.ToUserBadgeView(&badge))
 	}
 	return &BadgeViews{Badges: badgeViews, TotalCount: int(count)}
 }

--- a/internal/http/dtos/users.go
+++ b/internal/http/dtos/users.go
@@ -33,7 +33,7 @@ type UserProfileView struct {
 	Badges        *BadgeViews `json:"badges"`
 }
 
-func (UserDTOManager) ToUserProfile(userData sessionStore.SessionData, badges []repo.TBadge, badgeCount int64) UserProfileView {
+func (UserDTOManager) ToUserProfile(userData sessionStore.SessionData, badges []repo.GetUserBadgesRow, badgeCount int64) UserProfileView {
 	badgeManager := new(BadgeDTOManager)
 
 	return UserProfileView{
@@ -43,7 +43,7 @@ func (UserDTOManager) ToUserProfile(userData sessionStore.SessionData, badges []
 		Name:          userData.Name,
 		Surname:       userData.Surname,
 		WalletAddress: userData.WalletAddress,
-		Badges:        badgeManager.ToBadgeViews(badges, badgeCount),
+		Badges:        badgeManager.ToUserBadgeViews(badges, badgeCount),
 	}
 }
 

--- a/internal/http/v1/private/campaign.go
+++ b/internal/http/v1/private/campaign.go
@@ -103,6 +103,9 @@ func (h *PrivateHandler) CreateCampaign(c *fiber.Ctx) error {
 
 	imageFile, err := c.FormFile("imageFile")
 	if err != nil {
+		if strings.Contains(err.Error(), "there is no uploaded file associated with the given key") {
+			return response.Response(400, serviceErrors.ErrImageRequried, nil)
+		}
 		return err
 	}
 

--- a/internal/repos/out/models.go
+++ b/internal/repos/out/models.go
@@ -80,5 +80,6 @@ type TUserBadge struct {
 	ID        uuid.UUID
 	UserID    uuid.UUID
 	BadgeID   uuid.UUID
+	IsMinted  bool
 	AwardedAt sql.NullTime
 }

--- a/internal/repos/queries/userBadgets.sql
+++ b/internal/repos/queries/userBadgets.sql
@@ -1,6 +1,6 @@
 -- name: GetUserBadges :many
 SELECT 
-    b.id, b.symbol, b.name, b.description, b.seller_fee, b.icon_path, b.donation_threshold, b.uri, b.is_nft, b.created_at
+    b.id, b.symbol, b.name, b.description, b.seller_fee, b.icon_path, b.donation_threshold, b.uri, b.is_nft, ub.is_minted, b.created_at
 FROM 
     t_user_badges ub
 JOIN 
@@ -10,7 +10,7 @@ WHERE
 
 -- name: GetUserBadge :one
 SELECT 
-    b.id, b.symbol, b.name, b.description, b.seller_fee, b.icon_path, b.donation_threshold, b.uri, b.is_nft, b.created_at
+    b.id, b.symbol, b.name, b.description, b.seller_fee, b.icon_path, b.donation_threshold, b.uri, b.is_nft, ub.is_minted, b.created_at
 FROM 
     t_user_badges ub
 JOIN 
@@ -18,6 +18,14 @@ JOIN
 WHERE 
     ub.user_id = @user_id AND
     b.id = @badge_id;
+
+-- name: ChangeIsMinted :exec
+UPDATE
+    t_user_badges
+SET
+    is_minted = COALESCE(TRUE, is_minted)
+WHERE
+    user_id = @user_id AND badge_id = @badge_id;
 
 -- name: AddUserBadge :one
 INSERT INTO t_user_badges 

--- a/internal/services/badgets.go
+++ b/internal/services/badgets.go
@@ -219,11 +219,11 @@ func (s *BadgeService) UserBadgeExists(ctx context.Context, userID, badgeID uuid
 }
 
 // Get all badges a user has
-func (s *BadgeService) GetUserBadges(ctx context.Context, userID uuid.UUID) ([]repo.TBadge, error) {
+func (s *BadgeService) GetUserBadges(ctx context.Context, userID uuid.UUID) ([]repo.GetUserBadgesRow, error) {
 	return s.queries.GetUserBadges(ctx, userID)
 }
 
-func (s *BadgeService) GetUserBadge(ctx context.Context, badgeID string, userID uuid.UUID) (*repo.TBadge, error) {
+func (s *BadgeService) GetUserBadge(ctx context.Context, badgeID string, userID uuid.UUID) (*repo.GetUserBadgeRow, error) {
 	badgeUUID, err := s.utilService.NParseUUID(badgeID)
 	if err != nil {
 		return nil, err
@@ -271,6 +271,17 @@ func (s *BadgeService) CheckBadgeAndAdd(ctx context.Context, userID uuid.UUID, c
 	}
 
 	return &id, nil
+}
+
+func (s *BadgeService) ChangeIsMinted(ctx context.Context, userID, badgeID uuid.UUID) error {
+	if err := s.queries.ChangeIsMinted(ctx, repo.ChangeIsMintedParams{
+		UserID:  userID,
+		BadgeID: badgeID,
+	}); err != nil {
+		return serviceErrors.NewServiceErrorWithMessageAndError(serviceErrors.StatusInternalServerError, serviceErrors.ErrChangingMinted, err)
+	}
+
+	return nil
 }
 
 func (s *BadgeService) MintNFT(ctx context.Context, name, symbol, uri string, sellerFee int32, publicKey string) (map[string]interface{}, error) {

--- a/migrations/08_t_user_badges.sql
+++ b/migrations/08_t_user_badges.sql
@@ -5,6 +5,7 @@ CREATE TABLE IF NOT EXISTS t_user_badges (
     id UUID PRIMARY KEY NOT NULL DEFAULT uuid_generate_v4(),
     user_id UUID NOT NULL,
     badge_id UUID NOT NULL,
+    is_minted BOOLEAN NOT NULL DEFAULT FALSE,
     awarded_at TIMESTAMPTZ DEFAULT NOW(),
 
     CONSTRAINT fk_user FOREIGN KEY (user_id) REFERENCES t_users(id) ON DELETE CASCADE,


### PR DESCRIPTION
- Introduced new error messages for badge minting validation.
- Updated BadgeView and related DTOs to include IsMinted field.
- Modified service and repository methods to handle badge minting state.
- Enhanced SQL queries to support the new IsMinted attribute in user badges.
- Updated migration script to add IsMinted column to t_user_badges table.