### PR TITLE
Add user statistics endpoint and related functionality

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -1287,6 +1287,29 @@ const docTemplate = `{
                 }
             }
         },
+        "/private/user/statistic": {
+            "get": {
+                "description": "User, Donation and Campaign count.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Statistics"
+                ],
+                "summary": "Recives Statistic",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/response.BaseResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/public/auth": {
             "post": {
                 "description": "Auth with Wallet",

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -1280,6 +1280,29 @@
                 }
             }
         },
+        "/private/user/statistic": {
+            "get": {
+                "description": "User, Donation and Campaign count.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Statistics"
+                ],
+                "summary": "Recives Statistic",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/response.BaseResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/public/auth": {
             "post": {
                 "description": "Auth with Wallet",

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -950,6 +950,21 @@ paths:
       summary: Update User Profile
       tags:
       - User
+  /private/user/statistic:
+    get:
+      consumes:
+      - application/json
+      description: User, Donation and Campaign count.
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/response.BaseResponse'
+      summary: Recives Statistic
+      tags:
+      - Statistics
   /public/auth:
     post:
       consumes:

--- a/internal/errors/errorStr.go
+++ b/internal/errors/errorStr.go
@@ -61,6 +61,7 @@ const (
 	ErrFilteringCategories         = "ERROR_FILTERING_CATEGORIES"
 	ErrFilteringCampaignCategories = "ERROR_FILTERING_CATEGORIES"
 	ErrFilteringBadge              = "ERROR_FILTERING_BADGE"
+	ErrFetchingIstatistic          = "ERROR_FETCHING_ISTATISTIC"
 
 	ErrCreatingUser             = "ERROR_CREATE_USER"
 	ErrCreatingCampaigns        = "ERROR_CREATE_CAMPAINGS"

--- a/internal/http/sessionStore/session.go
+++ b/internal/http/sessionStore/session.go
@@ -25,7 +25,7 @@ func (s *SessionData) ParseFromUser(user *repo.TUser, role *repo.TRole) {
 	s.RoleID = user.RoleID
 	s.Role = role.Name
 	s.Name = user.Name.String
-	s.Email = user.Email
+	s.Email = user.Email.String
 	s.Surname = user.Surname.String
 	s.WalletAddress = user.WalletAddress
 }

--- a/internal/http/v1/private/user.go
+++ b/internal/http/v1/private/user.go
@@ -12,6 +12,7 @@ func (h *PrivateHandler) initUserRoutes(root fiber.Router) {
 	user.Get("/profile", h.Profile)
 	user.Post("/profile", h.UpdateProfile)
 	user.Post("/connect", h.ConnectWallet)
+	user.Get("/statistic", h.GetStatistics)
 }
 
 // @Tags User
@@ -124,4 +125,20 @@ func (h *PrivateHandler) ConnectWallet(c *fiber.Ctx) error {
 	}
 
 	return response.Response(200, "Status OK", nil)
+}
+
+// @Tags Statistics
+// @Summary Recives Statistic
+// @Description User, Donation and Campaign count.
+// @Accept json
+// @Produce json
+// @Success 200 {object} response.BaseResponse{}
+// @Router /private/user/statistic [get]
+func (h *PrivateHandler) GetStatistics(c *fiber.Ctx) error {
+	statistic, err := h.services.UserService().Statistics(c.Context())
+	if err != nil {
+		return err
+	}
+
+	return response.Response(200, "Statistic Recived", statistic)
 }

--- a/internal/repos/out/models.go
+++ b/internal/repos/out/models.go
@@ -70,7 +70,7 @@ type TUser struct {
 	ID            uuid.UUID
 	RoleID        uuid.UUID
 	WalletAddress string
-	Email         string
+	Email         sql.NullString
 	Name          sql.NullString
 	Surname       sql.NullString
 	IsDefault     bool

--- a/internal/repos/out/users.sql.go
+++ b/internal/repos/out/users.sql.go
@@ -75,7 +75,7 @@ type CreateUserParams struct {
 	RoleID        uuid.UUID
 	Name          sql.NullString
 	Surname       sql.NullString
-	Email         string
+	Email         sql.NullString
 	WalletAddress string
 	IsDefault     bool
 }
@@ -280,6 +280,26 @@ func (q *Queries) IsDefaultUserExists(ctx context.Context) (bool, error) {
 	return is_default_user_exists, err
 }
 
+const statistics = `-- name: Statistics :one
+SELECT 
+    (SELECT COUNT(*) FROM t_users) AS total_users,
+    (SELECT COUNT(*) FROM t_donations) AS total_donations,
+    (SELECT COUNT(*) FROM t_campaigns) AS total_campaigns
+`
+
+type StatisticsRow struct {
+	TotalUsers     int64
+	TotalDonations int64
+	TotalCampaigns int64
+}
+
+func (q *Queries) Statistics(ctx context.Context) (StatisticsRow, error) {
+	row := q.db.QueryRowContext(ctx, statistics)
+	var i StatisticsRow
+	err := row.Scan(&i.TotalUsers, &i.TotalDonations, &i.TotalCampaigns)
+	return i, err
+}
+
 const updateUser = `-- name: UpdateUser :exec
 UPDATE
     t_users
@@ -294,7 +314,7 @@ WHERE
 type UpdateUserParams struct {
 	Name    sql.NullString
 	Surname sql.NullString
-	Email   string
+	Email   sql.NullString
 	UserID  uuid.UUID
 }
 

--- a/internal/repos/queries/users.sql
+++ b/internal/repos/queries/users.sql
@@ -92,3 +92,9 @@ SELECT
         FROM t_users u
         WHERE u.is_default = true
     ) AS is_default_user_exists;
+
+-- name: Statistics :one
+SELECT 
+    (SELECT COUNT(*) FROM t_users) AS total_users,
+    (SELECT COUNT(*) FROM t_donations) AS total_donations,
+    (SELECT COUNT(*) FROM t_campaigns) AS total_campaigns;

--- a/internal/services/upload.go
+++ b/internal/services/upload.go
@@ -34,7 +34,7 @@ func (s *uploadService) SaveImage(file *multipart.FileHeader, filePath string) e
 
 	// Dosya uzantısını kontrol ediyoruz
 	ext := strings.ToLower(filepath.Ext(file.Filename))
-	if ext != ".jpg" && ext != ".jpeg" && ext != ".png" {
+	if ext != ".jpg" && ext != ".jpeg" && ext != ".png" && ext != ".heic" {
 		return serviceErrors.NewServiceErrorWithMessage(400, serviceErrors.ErrInvalidFileType)
 	}
 

--- a/internal/services/user.go
+++ b/internal/services/user.go
@@ -59,7 +59,7 @@ func (s *UserService) CivicLogin(ctx context.Context, fullName, email string, de
 		name, surname := paths.SplitFullName(fullName)
 		id, err := s.queries.CreateUser(ctx, repo.CreateUserParams{
 			RoleID:  defaultRoleID,
-			Email:   email,
+			Email:   s.utilService.ParseString(email),
 			Name:    s.utilService.ParseString(name),
 			Surname: s.utilService.ParseString(surname),
 		})
@@ -186,7 +186,7 @@ func (s *UserService) Update(ctx context.Context, id, name, surname, email strin
 		UserID:  idUUID,
 		Name:    s.utilService.ParseString(name),
 		Surname: s.utilService.ParseString(surname),
-		Email:   email,
+		Email:   s.utilService.ParseString(email),
 	}); err != nil {
 		return serviceErrors.NewServiceErrorWithMessage(serviceErrors.StatusInternalServerError, serviceErrors.ErrUpdatingUsers)
 	}
@@ -245,4 +245,13 @@ func (s *UserService) ChangeUserRole(ctx context.Context, id, newRoleID uuid.UUI
 	}
 
 	return nil
+}
+
+func (s *UserService) Statistics(ctx context.Context) (*repo.StatisticsRow, error) {
+	dbModel, err := s.queries.Statistics(ctx)
+	if err != nil {
+		return nil, serviceErrors.NewServiceErrorWithMessageAndError(serviceErrors.StatusInternalServerError, serviceErrors.ErrFetchingIstatistic, err)
+	}
+
+	return &dbModel, nil
 }


### PR DESCRIPTION
- Implemented GET /private/user/statistic to retrieve user, donation, and campaign counts.
- Updated Swagger documentation to include the new endpoint.
- Modified user model to use sql.NullString for email.
- Enhanced user service to handle statistics retrieval.
- Added error handling for fetching statistics.
- Allowed .heic file type in image upload service.